### PR TITLE
Feature/fix commons file upload for maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.3</version>
     </dependency>
     <dependency>
         <groupId>commons-io</groupId>

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/Cat.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/Cat.java
@@ -1,0 +1,42 @@
+package de.frei.springMvc.mvc.excelpdf;
+
+/**
+ * Class with new features name color weight
+ */
+
+public class Cat {
+
+    private String name;
+    private String color;
+    private int weight;
+
+    public Cat(String name, String color, int weight) {
+        this.name = name;
+        this.color = color;
+        this.weight = weight;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+
+    public void setWeight(int weight) {
+        this.weight = weight;
+    }
+}


### PR DESCRIPTION
Remediation

Upgrade commons-fileupload:commons-fileupload to version 1.3.3 or later. For example: