### PR TITLE
feature/JAVA-create-controllers-and-models

### DIFF
--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelDocument.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelDocument.java
@@ -1,0 +1,36 @@
+package de.frei.springMvc.mvc.excelpdf;
+
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.hssf.util.HSSFColor;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.springframework.web.servlet.view.document.AbstractExcelView;
+import org.springframework.web.servlet.view.document.AbstractXlsView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+
+
+public class ExcelDocument extends AbstractXlsView {
+
+
+    @Override
+    protected void buildExcelDocument(Map<String, Object> model,
+                                      Workbook workbook,
+                                      HttpServletRequest request,
+                                      HttpServletResponse response) throws Exception {
+
+        //New Excel sheet
+        Sheet excelSheet = workbook.createSheet("Simple excel example");
+        //Excel file name change
+        response.setHeader("Content-Disposition", "attachment; filename=excelDocument.xls");
+
+
+
+    }
+}

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelDocument.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelDocument.java
@@ -62,7 +62,7 @@ public class ExcelDocument extends AbstractXlsView {
 
     }
 
-    public void setExcelHeader(Sheet excelSheet, CellStyle styleHeader) {
+    private void setExcelHeader(Sheet excelSheet, CellStyle styleHeader) {
         //set Excel Header names
         Row header = excelSheet.createRow(0);
         header.createCell(0).setCellValue("Name");

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelDocument.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelDocument.java
@@ -1,13 +1,8 @@
 package de.frei.springMvc.mvc.excelpdf;
 
 
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.hssf.util.HSSFColor;
-import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.Font;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.springframework.web.servlet.view.document.AbstractExcelView;
+import org.apache.poi.ss.usermodel.*;
 import org.springframework.web.servlet.view.document.AbstractXlsView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -15,9 +10,20 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 
+/**
+ *
+ */
 
 public class ExcelDocument extends AbstractXlsView {
 
+    /**
+     *
+     * @param model   model for creating a file
+     * @param workbook file
+     * @param request  request for creating
+     * @param response responce from server
+     * @throws Exception common exception
+     */
 
     @Override
     protected void buildExcelDocument(Map<String, Object> model,
@@ -30,7 +36,40 @@ public class ExcelDocument extends AbstractXlsView {
         //Excel file name change
         response.setHeader("Content-Disposition", "attachment; filename=excelDocument.xls");
 
+        Font font = workbook.createFont();
+        font.setFontName("Arial");
+        font.setBoldweight(Font.BOLDWEIGHT_BOLD);
+        font.setColor(HSSFColor.WHITE.index);
 
+        //Create Style for header
+        CellStyle styleHeader = workbook.createCellStyle();
+        styleHeader.setFillForegroundColor(HSSFColor.BLUE.index);
+        styleHeader.setFillPattern(CellStyle.SOLID_FOREGROUND);
+        styleHeader.setFont(font);
 
+        //Set excel header
+        setExcelHeader(excelSheet, styleHeader);
+
+        //Get data from model
+        List<Cat> cats = (List<Cat>) model.get("modelObject");
+        int rowCount = 1;
+        for (Cat cat : cats) {
+            Row row = excelSheet.createRow(rowCount++);
+            row.createCell(0).setCellValue(cat.getName());
+            row.createCell(1).setCellValue(cat.getWeight());
+            row.createCell(2).setCellValue(cat.getColor());
+        }
+
+    }
+
+    public void setExcelHeader(Sheet excelSheet, CellStyle styleHeader) {
+        //set Excel Header names
+        Row header = excelSheet.createRow(0);
+        header.createCell(0).setCellValue("Name");
+        header.getCell(0).setCellStyle(styleHeader);
+        header.createCell(1).setCellValue("Wieght");
+        header.getCell(1).setCellStyle(styleHeader);
+        header.createCell(2).setCellValue("Color");
+        header.getCell(2).setCellStyle(styleHeader);
     }
 }

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
@@ -1,0 +1,33 @@
+package de.frei.springMvc.mvc.excelpdf;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class ExcelPDFController {
+
+    @RequestMapping(value = "/excel", method= RequestMethod.GET)
+    public ModelAndView excel() {
+        System.out.println("ExcelPDFController excel is called");
+
+        List<Cat> cats = createCats();
+
+        //excelDocument - look excel-pdf-config.xml
+        return new ModelAndView("excelDocument", "modelObject", cats);
+    }
+
+    private List<Cat> createCats() {
+        List<Cat> cats = new ArrayList<>();
+        for (int i = 0; i <10; i++) {
+            Cat cat = new Cat("cat" + i, "color" + i, i);
+            cats.add(cat);
+        }
+        return cats;
+    }
+}

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
@@ -9,6 +9,10 @@ import org.springframework.web.servlet.ModelAndView;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * ExcelPdfController - the main controller for coloboration between model and view
+ */
+
 @Controller
 public class ExcelPDFController {
 

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
@@ -23,6 +23,7 @@ public class ExcelPDFController {
         List<Cat> cats = createCats();
 
         //excelDocument - look excel-pdf-config.xml
+        //excelDocument as view
         return new ModelAndView("excelDocument", "modelObject", cats);
     }
 

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/ExcelPDFController.java
@@ -16,6 +16,11 @@ import java.util.List;
 @Controller
 public class ExcelPDFController {
 
+    /**
+     *
+     * @return cats from two GET requests as pdf and excel
+     */
+
     @RequestMapping(value = "/excel", method= RequestMethod.GET)
     public ModelAndView excel() {
         System.out.println("ExcelPDFController excel is called");
@@ -25,6 +30,17 @@ public class ExcelPDFController {
         //excelDocument - look excel-pdf-config.xml
         //excelDocument as view
         return new ModelAndView("excelDocument", "modelObject", cats);
+    }
+
+    @RequestMapping(value = "/pdf", method= RequestMethod.GET)
+    public ModelAndView pdf() {
+
+        System.out.println("ExcelPDFController pdf is called");
+
+        List<Cat> cats = createCats();
+        //pdfDocument - look excel-pdf-config.xml
+        return new ModelAndView("pdfDocument", "modelObject", cats);
+
     }
 
     private List<Cat> createCats() {

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/PDFDocument.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/PDFDocument.java
@@ -1,4 +1,48 @@
 package de.frei.springMvc.mvc.excelpdf;
 
-public class PDFDocument {
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import org.springframework.web.servlet.view.document.AbstractPdfView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+
+public class PDFDocument extends AbstractPdfView{
+
+    @Override
+    protected void buildPdfDocument(
+            Map<String, Object> model,
+            Document document,
+            PdfWriter writer,
+            HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+
+        PdfPTable table = new PdfPTable(3);
+        PdfPCell header1 = new PdfPCell(new Phrase("Name"));
+        PdfPCell header2 = new PdfPCell(new Phrase("Weight"));
+        PdfPCell header3 = new PdfPCell(new Phrase("Color"));
+        header1.setHorizontalAlignment(Element.ALIGN_LEFT);
+        header2.setHorizontalAlignment(Element.ALIGN_LEFT);
+        header3.setHorizontalAlignment(Element.ALIGN_LEFT);
+        table.addCell(header1);
+        table.addCell(header2);
+        table.addCell(header3);
+
+
+        //Get data from model
+        List<Cat> cats = (List<Cat>) model.get("modelObject");
+        for (Cat cat : cats) {
+            table.addCell(cat.getName());
+            table.addCell(String.valueOf(cat.getWeight()));
+            table.addCell(cat.getColor());
+        }
+        document.add(table);
+    }
 }

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/PDFDocument.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/PDFDocument.java
@@ -1,0 +1,4 @@
+package de.frei.springMvc.mvc.excelpdf;
+
+public class PDFDocument {
+}

--- a/src/test/java/JUnit5Test.java
+++ b/src/test/java/JUnit5Test.java
@@ -15,5 +15,11 @@ public class JUnit5Test {
         justAnTest();
         System.out.print("the all tests was loaded");
     }
+    @Test
+    public void nextTest(){
+        justAnTest();
+        secondTest();
+        System.out.print("TEST 3 is DONE");
+    }
 
 }

--- a/webapp/WEB-INF/config/excel-pdf-config.xml
+++ b/webapp/WEB-INF/config/excel-pdf-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+						   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+    <!-- When a controller returns excelDocument render the model with the spring.mvc.excelpdf.ExcelDocument class -->
+    <bean id="excelDocument"  class="de.frei.springMvc.mvc.excelpdf.ExcelDocument" />
+
+    <!-- When a controller returns pdfDocument render the model with the spring.mvc.excelpdf.PDFDocument class -->
+    <bean id="pdfDocument"  class="de.frei.springMvc.mvc.excelpdf.PDFDocument"/>
+
+</beans>

--- a/webapp/WEB-INF/config/mvc-config.xml
+++ b/webapp/WEB-INF/config/mvc-config.xml
@@ -14,6 +14,15 @@
          and also resolves @Autowired and @Qualifier -->
     <context:component-scan base-package="de.frei.springMvc.mvc" />
 
+    <mvc:annotation-driven>
+    <!--
+        mvc:annotation-driven configures Spring MVC annotations
+        Support for validating @Controller inputs with @Valid, if a JSR-303 Provider is present on the classpath.
+        HttpMessageConverter support for @RequestBody method parameters and @ResponseBody method return values
+        from @RequestMapping or @ExceptionHandler methods.
+     -->
+    </mvc:annotation-driven>
+
     <!-- ViewResolver bean config for mapping strings to jsp views -->
     <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
         <!-- Example: a logical view name of 'showMessage' is mapped to '/WEB-INF/jsp/showMessage.jsp' -->
@@ -22,9 +31,24 @@
         <property name="suffix" value=".jsp" />
     </bean>
 
+    <!-- File Upload bean config-->
+    <bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
+        <!-- set the maximum file size in bytes -->
+        <property name="maxUploadSize" value="1000000"/>
+    </bean>
+
+    <!--Excel and PDF xml view configuration -->
+    <bean class="org.springframework.web.servlet.view.XmlViewResolver">
+        <property name="order" value="0" />
+        <property name="location">
+            <value>/WEB-INF/config/excel-pdf-config.xml</value>
+        </property>
+    </bean>
+
 
     <mvc:view-controller path="/about.html" view-name="/about/about"/>
     <mvc:view-controller path="/index.html" view-name="/index"/>
+    <mvc:view-controller path="/file.html" view-name="/file/file"/>
 
 
 </beans>


### PR DESCRIPTION
AbstractExcelView is deprecated in Spring-based application

As of Spring 4.2, instead of AbstractExcelView you can try AbstractXlsView and its AbstractXlsxView and AbstractXlsxStreamingView variants

model class (Cat) and a controller that will process requests from a jsp page (ExcelPDFController)

added ExcelDocument.java for creating a document