### PR TITLE
feature/MVC-file-upload-controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:7
+
+MAINTAINER Sascha F. Andreichenko <andreichenko@web.de>
+#The Salt Bootstrap Script allows a user to install the Salt Minion or Master on a variety of system distributions and version but it's a issue
+
+#mount cgroup
+VOLUME [ "/sys/fs/cgroup" ]
+
+#install openSSH
+RUN yum install -y openssh-server \
+    openssh-clients
+
+RUN yum clean all
+
+# ready for using
+CMD ["/usr/sbin/init"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ timestamps {
         ls -la  webapp/resources
         ls -la  webapp/WEB-INF/view/about
         cat webapp/WEB-INF/view/about/about.jsp
+        cat Dockerfile
         '''
         }
 

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/Cat.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/Cat.java
@@ -6,6 +6,10 @@ package de.frei.springMvc.mvc.excelpdf;
 
 public class Cat {
 
+    /**
+     * MOCK-class
+     */
+
     private String name;
     private String color;
     private int weight;

--- a/src/main/java/de/frei/springMvc/mvc/excelpdf/PDFDocument.java
+++ b/src/main/java/de/frei/springMvc/mvc/excelpdf/PDFDocument.java
@@ -14,7 +14,21 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * created by Sascha Frei
+ */
+
 public class PDFDocument extends AbstractPdfView{
+
+    /**
+     *
+     * @param model this is the parameter of our model for mapping
+     * @param document documents' parameter itself
+     * @param writer writer to the file
+     * @param request request to api
+     * @param response response from api
+     * @throws Exception the common exception
+     */
 
     @Override
     protected void buildPdfDocument(

--- a/src/main/java/de/frei/springMvc/mvc/file/FileUploadController.java
+++ b/src/main/java/de/frei/springMvc/mvc/file/FileUploadController.java
@@ -1,4 +1,57 @@
 package de.frei.springMvc.mvc.file;
 
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * created by Sascha Frei
+ */
+
+@Controller
 public class FileUploadController {
+
+    /**
+     *
+     * @param file  a file
+     * @return body of file or file itself
+     */
+
+    @RequestMapping(value = "/uploadFile", method = RequestMethod.POST)
+    public @ResponseBody String handleFileUpload(@RequestParam("file") MultipartFile file) {
+
+        if (!file.isEmpty()) {
+
+            try {
+
+                byte[] fileBytes = file.getBytes();
+                String rootPath = System.getProperty("catalina.home");
+                System.out.println("Server rootPath: " + rootPath);
+                System.out.println("File original name: " + file.getOriginalFilename());
+                System.out.println("File content type: " + file.getContentType());
+
+                File newFile = new File(rootPath + File.separator + file.getOriginalFilename());
+                BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(newFile));
+                stream.write(fileBytes);
+                stream.close();
+
+                System.out.println("File is saved under: " + rootPath + File.separator + file.getOriginalFilename());
+                return "File is saved under: " + rootPath + File.separator + file.getOriginalFilename();
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "File upload is failed: " + e.getMessage();
+            }
+        } else {
+            return "File upload is failed: File is empty";
+        }
+    }
 }

--- a/src/main/java/de/frei/springMvc/mvc/file/FileUploadController.java
+++ b/src/main/java/de/frei/springMvc/mvc/file/FileUploadController.java
@@ -1,0 +1,4 @@
+package de.frei.springMvc.mvc.file;
+
+public class FileUploadController {
+}


### PR DESCRIPTION
To load the Spring MVC file, we use our MultipartResolver interface (we will use the CommonsMultipartResolver class that implements it). Work with him is very simple. All you need to do is specify the mapping by which the controller intercepts the request to download the file. Further in the class, standard work with byte streams and file recording are used.

added

    - FileUploadController.java